### PR TITLE
fix: category navigation click issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,7 +147,7 @@ function App() {
                   {!isLastCategory ? (
                     <div className="pt-4 border-t">
                       <Button 
-                        onClick={handleNextCategory}
+                        onMouseDown={handleNextCategory}
                         className="w-full gap-2"
                         variant="default"
                       >
@@ -158,7 +158,7 @@ function App() {
                   ) : (
                     <div className="pt-4 border-t">
                       <Button 
-                        onClick={handleDone}
+                        onMouseDown={handleDone}
                         className="w-full gap-2"
                         variant="default"
                       >


### PR DESCRIPTION
Changes onClick to onMouseDown for the navigation buttons. This ensures the action triggers immediately when the user presses down, preventing the 'blur' event from the textarea (when it shrinks/shifts) from swallowing the click event.

## Summary by Sourcery

Bug Fixes:
- Fix category navigation buttons not firing when a textarea blur event interferes with the click.