### PR TITLE
feat: add domain and personal site to export footer

### DIFF
--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -52,6 +52,9 @@ export function ExportDialog({ open, onOpenChange, data }: ExportDialogProps) {
     lines.push('---')
     lines.push('')
     lines.push(`*Generated on ${new Date().toLocaleDateString()}*`)
+    lines.push('')
+    lines.push(`*Generated at: [ai-assistant-human-questionnaire.vercel.app](https://ai-assistant-human-questionnaire.vercel.app/)*`)
+    lines.push(`*Created by: [www.brettsanders.com](https://www.brettsanders.com)*`)
 
     return lines.join('\n')
   }


### PR DESCRIPTION
Adds the questionnaire domain and Brett's personal site to the generated Markdown export footer.

## Summary by Sourcery

Add additional metadata links to the Markdown export footer.

New Features:
- Include the questionnaire domain URL in the generated Markdown export footer.
- Include the author's personal website link in the generated Markdown export footer.